### PR TITLE
fix: typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ to be written with tailwind:
 
 ```html
 <div
-  class="border-image-gradient-to-l form-indigo-900 to-indigo-300 border-slice-1 border-width-0 border-outset-x-full border-repeat-stretch"
+  class="border-image-gradient-to-l from-indigo-900 to-indigo-300 border-slice-1 border-width-0 border-outset-x-full border-repeat-stretch"
 ></div>
 ```
 


### PR DESCRIPTION
Changes `form-indigo-900` to `from-indigo-900`